### PR TITLE
add body comp logging

### DIFF
--- a/health_assistant/body_agent.py
+++ b/health_assistant/body_agent.py
@@ -1,0 +1,55 @@
+import os
+from agents import Agent, function_tool
+from pyairtable import Api
+
+# setup body data log tool
+@function_tool
+def write_body_log(
+    weight_lb: float,
+    smm_lb: float,
+    pbf: float,
+    ecw_tcw: float
+) -> str:
+    """
+    Write body composition information to the user's external log.
+    
+    This tool allows recording of body composition metrics for the user into a persistent
+    storage system. It captures 4 metrics - weight, skeletal muscle mass, body fat percentage, and ECW/TCW ratio.
+    
+    Args:
+        weight_lb (float): Body weight in lbs
+        smm_lb (float): Skeletal muscle mass in lbs
+        pbf (float): Body fat percentage in decimal format, e.g. 0.25 for 25%
+        ecw_tcw (float): Extracellular water to total body water ratio in decimal format, e.g. 0.4 for 40%
+    
+    Returns:
+        str: The record ID of the created entry if successful
+    
+    Example:
+        record_id = write_body_log(169.7, 82.5, 0.150, 0.365)
+    """
+    api = Api(os.getenv("AIRTABLE_PAT"))
+    table = api.table(os.getenv("AIRTABLE_BASE_ID"), "body_log")
+    
+    record = table.create({
+        "weight_lb": weight_lb,
+        "smm_lb": smm_lb,
+        "pbf": pbf,
+        "ecw_tcw": ecw_tcw
+    })
+    
+    return record["id"]
+
+# setup agent
+with open("instructions/body-agent.txt", "r") as file:
+    instructions = file.read()
+body_agent = Agent(
+    name="Body Composition Agent", 
+    instructions=instructions,
+    model="gpt-4o-mini",
+    tools = [
+        write_body_log
+    ],
+    handoff_description="""Parses body composition information and logs it for the user.  
+                        Any prompt mentioning body composition metrics should be passed here."""
+)

--- a/health_assistant/body_agent.py
+++ b/health_assistant/body_agent.py
@@ -8,19 +8,19 @@ def write_body_log(
     weight_lb: float,
     smm_lb: float,
     pbf: float,
-    ecw_tcw: float
+    ecw_tbw: float
 ) -> str:
     """
     Write body composition information to the user's external log.
     
     This tool allows recording of body composition metrics for the user into a persistent
-    storage system. It captures 4 metrics - weight, skeletal muscle mass, body fat percentage, and ECW/TCW ratio.
+    storage system. It captures 4 metrics - weight, skeletal muscle mass, body fat percentage, and ECW/TBW ratio.
     
     Args:
         weight_lb (float): Body weight in lbs
         smm_lb (float): Skeletal muscle mass in lbs
         pbf (float): Body fat percentage in decimal format, e.g. 0.25 for 25%
-        ecw_tcw (float): Extracellular water to total body water ratio in decimal format, e.g. 0.4 for 40%
+        ecw_tbw (float): Extracellular water to total body water ratio in decimal format, e.g. 0.4 for 40%
     
     Returns:
         str: The record ID of the created entry if successful
@@ -35,7 +35,7 @@ def write_body_log(
         "weight_lb": weight_lb,
         "smm_lb": smm_lb,
         "pbf": pbf,
-        "ecw_tcw": ecw_tcw
+        "ecw_tbw": ecw_tbw
     })
     
     return record["id"]

--- a/health_assistant/health_assistant.py
+++ b/health_assistant/health_assistant.py
@@ -1,6 +1,7 @@
 from agents import Agent
 from .nutrition_agent import nutrition_agent
 from .heart_health_agent import heart_health_agent
+from .body_agent import body_agent
 
 # setup agent
 with open("instructions/orchestration-agent.txt", "r") as file:
@@ -10,5 +11,5 @@ health_assistant = Agent(
     name="Health Assistant",
     instructions=instructions,
     model="gpt-4o-mini",
-    handoffs=[nutrition_agent, heart_health_agent],
+    handoffs=[nutrition_agent, heart_health_agent, body_agent],
 )

--- a/health_assistant/heart_health_agent.py
+++ b/health_assistant/heart_health_agent.py
@@ -43,7 +43,7 @@ with open("instructions/heart-health-agent.txt", "r") as file:
 heart_health_agent = Agent(
     name="Heart Health Agent", 
     instructions=instructions,
-    model="gpt-4o",
+    model="gpt-4o-mini",
     tools = [
         write_heart_log
     ],

--- a/instructions/body-agent.txt
+++ b/instructions/body-agent.txt
@@ -3,12 +3,12 @@ The metrics you should be looking for include:
  - body weight (lbs)
  - skeletal muscle mass, or smm (lbs)
  - percent body fat, or pbf 
- - Etracellular water to total body water ratio, or ecw/tcw 
+ - Etracellular water to total body water ratio, or ecw/tbw 
 All four of the metrics do not have to be present to proceed, but you must log any and all that the user provides.
-Often, the user will provide the numbers in a conversational manner, e.g. "Today, I weighed 169.7, with 82.5 lbs muscle, 15% body fat, and an ecw/tcw of 0.365.".  In this case, for example, you should log the metrics as:
+Often, the user will provide the numbers in a conversational manner, e.g. "Today, I weighed 169.7, with 82.5 lbs muscle, 15% body fat, and an ecw/tbw of 0.365.".  In this case, for example, you should log the metrics as:
  - body weight: 169.7
  - smm: 82.5
  - pbf: 0.15
- - ecw_tcw: 0.365
+ - ecw_tbw: 0.365
 
 After you have logged the body composition metrics, respond to the user with a message stating that you have successfully logged the metrics, provide the values of the metrics, and also include the record ID of the newly created record.

--- a/instructions/body-agent.txt
+++ b/instructions/body-agent.txt
@@ -1,0 +1,14 @@
+You are a body composition assistant to the user, named Coy McNew.  Your job is to read a prompt containing body composition metrcis and log them in the body composition table.
+The metrics you should be looking for include:
+ - body weight (lbs)
+ - skeletal muscle mass, or smm (lbs)
+ - percent body fat, or pbf 
+ - Etracellular water to total body water ratio, or ecw/tcw 
+All four of the metrics do not have to be present to proceed, but you must log any and all that the user provides.
+Often, the user will provide the numbers in a conversational manner, e.g. "Today, I weighed 169.7, with 82.5 lbs muscle, 15% body fat, and an ecw/tcw of 0.365.".  In this case, for example, you should log the metrics as:
+ - body weight: 169.7
+ - smm: 82.5
+ - pbf: 0.15
+ - ecw_tcw: 0.365
+
+After you have logged the body composition metrics, respond to the user with a message stating that you have successfully logged the metrics, provide the values of the metrics, and also include the record ID of the newly created record.


### PR DESCRIPTION
This PR adds a body composition logger, which logs the following metrics:

- Body weight in lbs
- Skeletal muscle mass in lbs
- Percent body fat in decimal format
- Extracellular water to total body water ratio in decimal format

The logger was added as a subagent, to which the orchestrator should pass any body composition metrics.